### PR TITLE
Correct command name to match command palette

### DIFF
--- a/drams/calva_getting_started/hello_paredit.clj
+++ b/drams/calva_getting_started/hello_paredit.clj
@@ -59,8 +59,8 @@
 ;; There is also *Paredit Shrink Selection*
 
 ;; == Navigate the Structure ==
-;; Move form-by-form using *Paredit Sexp Forward*
-;; and *Paredit Sexp Backward*
+;; Move form-by-form using *Paredit Forward Sexp*
+;; and *Paredit Backward Sexp*
 ;; Note: Despite what the command palette is showing, the
 ;; Keyboard shortcuts for For Mac are alt+right/left and
 ;; for Windows and Linux they are ctrl+right/left


### PR DESCRIPTION
I noticed that the name in the comment had Sexp and (Forward | Backward) in the reverse order to the command palette. In combination with the completion algorithm in the command palette this was slightly unhelpful.