### PR TITLE
Fix namespace of the `::foo` check

### DIFF
--- a/drams/calva_getting_started/src/get_started/welcome_to_clojure.clj
+++ b/drams/calva_getting_started/src/get_started/welcome_to_clojure.clj
@@ -831,7 +831,7 @@ to the compiler") "This is not ignored"
   ;; keywords get namespaced with the current namespace
 
   ::foo
-  (= ::foo :calva-getting-started.src.get-started.welcome-to-clojure/foo)
+  (= ::foo :get-started.welcome-to-clojure/foo)
 
   ;; Tagged literals, then. It's a way to invoke functions
   ;; bound to the tags on the form following it.


### PR DESCRIPTION
Probably the reference to the outer parts is no longer necessary to provide a `true` response. (Tested on WSL2 and Windows 11.)
(Of course a `false` response is also fine, but I had the impression that `true` was expected.)